### PR TITLE
fix: Negotiation 수정 로직 변경

### DIFF
--- a/src/main/java/com/example/market/constants/NegotiationStatusType.java
+++ b/src/main/java/com/example/market/constants/NegotiationStatusType.java
@@ -1,8 +1,10 @@
 package com.example.market.constants;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public enum NegotiationStatusType {
 	제안,
 	수락,

--- a/src/main/java/com/example/market/controller/NegotiationController.java
+++ b/src/main/java/com/example/market/controller/NegotiationController.java
@@ -1,8 +1,8 @@
 package com.example.market.controller;
 
 import com.example.market.dto.request.NegotiationDeleteRequest;
-import com.example.market.dto.request.NegotiationRequest;
-import com.example.market.dto.request.NegotiationStatusRequest;
+import com.example.market.dto.request.NegotiationCreateRequest;
+import com.example.market.dto.request.NegotiationModifyRequest;
 import com.example.market.dto.response.Response;
 import com.example.market.dto.response.ResponseMessage;
 import com.example.market.exception.ApplicationException;
@@ -26,36 +26,33 @@ public class NegotiationController {
 	private final NegotiationService negotiationService;
 
 	@PostMapping
-	public Response<String> create(@PathVariable Long itemId, @RequestBody NegotiationRequest request){
+	public Response<String> create(@PathVariable Long itemId, @RequestBody NegotiationCreateRequest request)
+	{
 		negotiationService.create(itemId, request.getWriter(), request.getPassword(), request.getSuggestedPrice());
 		return Response.success(ResponseMessage.SUCCESS_NEGOTIATION_CREATE);
 	}
 	@PutMapping("/{proposalId}")
 	public Response<String> modify(@PathVariable Long itemId,
 								@PathVariable Long proposalId,
-								@RequestBody NegotiationRequest request){
-		negotiationService.modify(itemId, proposalId, request.getWriter(), request.getPassword(), request.getSuggestedPrice());
-		return Response.success(ResponseMessage.SUCCESS_NEGOTIATION_MODIFY);
-	}
-
-	@PutMapping("/{proposalId}/status")// 엔드포인트 중복으로 ambiguous 에러 나서 변경
-	public Response<String> updateStatus(@PathVariable Long itemId,
-										@PathVariable Long proposalId,
-										@RequestBody NegotiationStatusRequest request){
-		negotiationService.updateStatus(itemId, proposalId, request.getWriter(), request.getPassword(), request.getStatus());
+								@RequestBody NegotiationModifyRequest request)
+	{
+		negotiationService.modify(itemId, proposalId, request.getWriter(), request.getPassword(), request.getSuggestedPrice(), request.getStatus());
 
 		switch(request.getStatus()){
 			case "확정":
+				negotiationService.rejectProposals(itemId);// 해당 아이템의 제안들을 거절상태로 변경
 				return Response.success(ResponseMessage.SUCCESS_NEGOTIATION_APPROVED);
 			case "수락":
 			case "거절":
 				return Response.success(ResponseMessage.SUCCESS_NEGOTIATION_STATUS);
 		}
-		throw new ApplicationException(ErrorCode.INVALID_STATUS);
+		return Response.success(ResponseMessage.SUCCESS_NEGOTIATION_MODIFY);
 	}
+
 	@DeleteMapping("/{proposalId}")
 	public Response<String> delete(@PathVariable Long proposalId,
-								@RequestBody NegotiationDeleteRequest request){
+								@RequestBody NegotiationDeleteRequest request)
+	{
 		negotiationService.delete(proposalId, request.getWriter(), request.getPassword());
 		return Response.success(ResponseMessage.SUCCESS_NEGOTIATION_DELETE);
 	}

--- a/src/main/java/com/example/market/dto/request/NegotiationCreateRequest.java
+++ b/src/main/java/com/example/market/dto/request/NegotiationCreateRequest.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class NegotiationRequest {
+public class NegotiationCreateRequest {
 	private String writer;
 	private String password;
 	private int suggestedPrice;

--- a/src/main/java/com/example/market/dto/request/NegotiationModifyRequest.java
+++ b/src/main/java/com/example/market/dto/request/NegotiationModifyRequest.java
@@ -5,9 +5,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class NegotiationStatusRequest {
+public class NegotiationModifyRequest {
 	private String writer;
 	private String password;
+	private int suggestedPrice;
 	private String status;
 
 }

--- a/src/main/java/com/example/market/entity/NegotiationEntity.java
+++ b/src/main/java/com/example/market/entity/NegotiationEntity.java
@@ -63,14 +63,28 @@ public class NegotiationEntity extends BaseDateEntity{
 			.status(status)
 			.build();
 	}
-	public NegotiationEntity updateNegotiation(String writer, String password, int suggestedPrice){
+	public NegotiationEntity updateSuggestedPrice(String writer, String password, int suggestedPrice){
 		this.writer = writer;
 		this.password = password;
 		this.suggestedPrice = suggestedPrice;
 		return this;
 	}
-	public NegotiationEntity updateStatus(NegotiationStatusType type){
-		this.status = type;
+
+	public NegotiationEntity updateStatus(String requestStatus){
+		NegotiationStatusType newStatusType = NegotiationStatusType.제안;// 초깃값 설정
+
+		switch(requestStatus){
+			case "수락":
+				newStatusType = NegotiationStatusType.수락;
+				break;
+			case "거절":
+				newStatusType = NegotiationStatusType.거절;
+				break;
+			case "확정":
+				newStatusType = NegotiationStatusType.확정;
+				break;
+		}
+		this.status = newStatusType;
 		return this;
 	}
 }


### PR DESCRIPTION
- writer가 상품의 writer인지 네고의 writer인지에 따라 분기하는 로직으로 변경 
- service, controller 코드의 중복 제거 